### PR TITLE
idle-view component: correct class set var name

### DIFF
--- a/src/components/Idle.vue
+++ b/src/components/Idle.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="idle-view" :class="{isIdle: isIdle}">
+  <div class="idle-view" :class="{isIdle: isAppIdle}">
     <div class="overlay"></div>
     <sprite spriteId="touch"
       :spriteSrc="require('../assets/touch.png')"


### PR DESCRIPTION
Fixes idle-view component not ever becoming active due to previous class setting variable not being instantiated.